### PR TITLE
Changes response status from string to integer.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
   from = "/*"
   to = "/index.html"
-  status = "200"
+  status = 200


### PR DESCRIPTION
# Description

Was previously `status = "200"`, which caused netlify to throw an error about type coercion.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)