### PR TITLE
Changed the watson response data from just document to document and s…

### DIFF
--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -44,7 +44,7 @@ class NewEmail extends Component {
   analyzeText = () => {
     axios
       .post('http://localhost:5000/api/watson', {text: this.state.text})
-      .then(res => this.setState({analysis: res.data.document_tone}))
+      .then(res => this.setState({analysis: res.data}))
       .catch(err => this.setState({error: err}))
   }
 


### PR DESCRIPTION

# Description
This change writes comprehensive Watson data to state. The prior code only wrote the DOCUMENT analysis to state. That means we would only be able to evaluate the document or the body of the email as a whole. This change now writes to state the entire message analysis.

Fixes # (issue)
  We hadn't seen this be a problem, yet.
## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)


## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
 I manually tested this change.

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
