### PR TITLE
Changed Sidebar path from '/documents' to '/'

### DIFF
--- a/client/src/components/Navigation/Sidebar.js
+++ b/client/src/components/Navigation/Sidebar.js
@@ -6,7 +6,7 @@ export default class Sidebar extends Component {
     render() {
         return(
             <div className='sideBar'>
-                <Link to='/documents'>
+                <Link to='/'>
                     <button>
                         <strong>Home</strong>
                     </button>


### PR DESCRIPTION
# Description

Changed sidebar path from '/documents'  to '/' so. '/documents' is an empty page.

# Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
