### PR TITLE
Improves styling of Editor component. Now matches other form inputs!

### DIFF
--- a/client/src/components/emailcreate/Editor.js
+++ b/client/src/components/emailcreate/Editor.js
@@ -1,31 +1,36 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React from "react";
+import ReactDOM from "react-dom";
 
 class ContentEditable extends React.Component {
   render = () => {
-    return <div 
-      onInput={this.emitChange} 
-      onBlur={this.emitChange}
-      contentEditable
-      dangerouslySetInnerHTML={{__html: this.props.html}}></div>;
-  }
+    return (
+      <div
+        className="form-control"
+        style={{ height: "auto" }}
+        onInput={this.emitChange}
+        onBlur={this.emitChange}
+        contentEditable
+        dangerouslySetInnerHTML={{ __html: this.props.html }}
+      />
+    );
+  };
 
-  shouldComponentUpdate = (nextProps) => {
+  shouldComponentUpdate = nextProps => {
     return nextProps.html !== ReactDOM.findDOMNode(this).innerHTML;
-  }
+  };
 
   emitChange = () => {
     var html = ReactDOM.findDOMNode(this).innerHTML;
     if (this.props.onChange && html !== this.lastHtml) {
       this.props.onChange({
         target: {
-            name: "text",
-            value: html
+          name: "text",
+          value: html
         }
       });
     }
     this.lastHtml = html;
-  }
+  };
 }
 
 export default ContentEditable;

--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -211,14 +211,11 @@ class NewEmail extends Component {
               </div>
               <div className="row align-items-center">
                 <div className="col">
-                  {/*This editor component doesn't look like a form field. I'm not sure what's going on here -Chad*/}
-                  <div className="border border-light form-group">
                     <Editor
                       html={this.state.text}
                       onChange={this.handleInputChange}
                     />
                   </div>
-                </div>
                 {/*I thought we'd have a column next to the text where the analysis and colors pop up
         Also, we can have a CSS class that governs their behavior when they get added or changed as a result of the analysis
            -Chad*/}


### PR DESCRIPTION
# Description

Editor previously had very bare styling, and was hard to see. Initial attempts to match to other form controls had caused visual bugs related to element height, which was resolved with the use of a `height: auto` style on the innermost `div`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Looked at it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
