### PR TITLE
made another path in analysis component

### DIFF
--- a/client/src/components/emailcreate/Analysis.js
+++ b/client/src/components/emailcreate/Analysis.js
@@ -1,18 +1,23 @@
 import React from 'react';
 
 const Analysis = (props) => {
-  if (
-    props.toneAnalysis === null ||
-    props.toneAnalysis.document_tone.tones.length === 0
-  ) {
+  console.log(props.toneAnalysis);
+  if (props.toneAnalysis === null) {
     return (
       <div>
         <p>No analysis. Click the Analyze Button</p>
       </div>
     );
+  } else if (props.toneAnalysis.document_tone.tones.length === 0) {
+    return (
+      <div>
+        <p>The document does not have a tone to it.</p>
+      </div>
+    );
   } else {
     return (
       <div>
+        <p>Document tones:</p>
         {props.toneAnalysis.document_tone.tones.map((e, i) => {
           return (
             <p key={i}>


### PR DESCRIPTION
# Description

Gave condition where props.toneAnalysis.document_tones.tones has a length of 0 it's own render path.  There seems to be an issue where if you delete all text and click analyze after an analysis that the state doesn't change and one would need to write something again in the document and click analyze again for state to change and a different view to be rendered.
Fixes # (issue)

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
