### PR TITLE
Limit user analyze in populate users

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,12 +5,12 @@ import './App.css';
 import MainContent from './components/MainContent';
 import LandingPage from './components/LandingPage';
 import 'typeface-montserrat';
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { fab } from '@fortawesome/free-brands-svg-icons'
-import { faIgloo } from '@fortawesome/free-solid-svg-icons'
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { fab } from '@fortawesome/free-brands-svg-icons';
+import { faIgloo } from '@fortawesome/free-solid-svg-icons';
 
-library.add(faIgloo, fab)
+library.add(faIgloo, fab);
 
 class App extends Component {
   state = {
@@ -19,7 +19,9 @@ class App extends Component {
 
   updateUser = () => {
     axios
-      .get(process.env.REACT_APP_PROFILE_URL, { withCredentials: true })
+      .get(process.env.REACT_APP_BACKEND_URL + '/auth/profile', {
+        withCredentials: true,
+      })
       .then((response) => {
         const { user, err } = response.data;
         if (user) {

--- a/client/src/components/Billing/Checkout.js
+++ b/client/src/components/Billing/Checkout.js
@@ -1,28 +1,28 @@
-import React from "react";
-import axios from "axios";
-import StripeCheckout from "react-stripe-checkout";
+import React from 'react';
+import axios from 'axios';
+import StripeCheckout from 'react-stripe-checkout';
 
-const PAYMENT_SERVER_URL = process.env.REACT_APP_PAYMENT_SERVER_URL;
+const PAYMENT_SERVER_URL = process.env.REACT_APP_BACKEND_URL + '/billing';
 const STRIPE_PUBLISHABLE = process.env.REACT_APP_STRIPE_API_PUBLISH_KEY;
 
-const CURRENCY = "USD";
+const CURRENCY = 'USD';
 
 // All API requests expect amounts to be provided in a currency’s smallest unit.
 // For example, to charge $10 USD, provide an amount value of 1000 (i.e, 1000 cents).
 
-const fromUSDToCent = amount => amount * 100;
+const fromUSDToCent = (amount) => amount * 100;
 
-const successPayment = data => {
-  alert("Payment Successful");
+const successPayment = (data) => {
+  alert('Payment Successful');
   console.log(data);
 };
 
-const errorPayment = data => {
-  alert("Payment Error");
+const errorPayment = (data) => {
+  alert('Payment Error');
   console.log(data);
 };
 
-const onToken = (amount, description) => token =>
+const onToken = (amount, description) => (token) =>
   axios
     .post(
       PAYMENT_SERVER_URL,
@@ -30,7 +30,7 @@ const onToken = (amount, description) => token =>
         description,
         source: token.id,
         currency: CURRENCY,
-        amount: fromUSDToCent(amount)
+        amount: fromUSDToCent(amount),
       },
       { withCredentials: true }
     )

--- a/client/src/components/DocumentList/index.js
+++ b/client/src/components/DocumentList/index.js
@@ -19,7 +19,9 @@ class DocumentList extends Component {
 
   fetchEmails = () => {
     axios
-      .get(process.env.REACT_APP_EMAILS_URL, { withCredentials: true })
+      .get(process.env.REACT_APP_BACKEND_URL + '/emails', {
+        withCredentials: true,
+      })
       .then(({ data }) => {
         const { emails, err } = data;
         if (emails) {
@@ -56,7 +58,7 @@ class DocumentList extends Component {
   };
   deleteEmail = (e) => {
     axios
-      .delete(`${process.env.REACT_APP_EMAILS_URL}${e.id}`, {
+      .delete(`${process.env.REACT_APP_BACKEND_URL + '/emails/'}${e.id}`, {
         withCredentials: true,
       })
       .then((res) => {
@@ -74,7 +76,9 @@ class DocumentList extends Component {
       const body = { email: { title, addressee } };
       console.log(body);
       axios
-        .post(process.env.REACT_APP_EMAILS_URL, body, { withCredentials: true })
+        .post(process.env.REACT_APP_BACKEND_URL + '/emails', body, {
+          withCredentials: true,
+        })
         .then(({ data }) => {
           if (data.id) {
             this.fetchEmails();

--- a/client/src/components/LandingPage/index.js
+++ b/client/src/components/LandingPage/index.js
@@ -1,260 +1,429 @@
 import React, { Component } from 'react';
 import './assets/css/index.css';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class LandingPage extends Component {
-    // constructor(props) {
-    //     super(props);
-    // }
+  // constructor(props) {
+  //     super(props);
+  // }
 
-    render() {
-      return (
-<div>
-    <nav className="navbar navbar-expand-lg fixed-top navbar-transparent" color-on-scroll="300">
-        <div className="container">
-			<div className="navbar-translate">
-				<a className="navbar-brand" href="#">Don't send that email</a>
-	            <button className="navbar-toggler navbar-toggler-right navbar-burger" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
-					<span className="navbar-toggler-bar"></span>
-					<span className="navbar-toggler-bar"></span>
-					<span className="navbar-toggler-bar"></span>
-	            </button>
-			</div>
-	        <div className="collapse navbar-collapse" id="navbarToggler">
-	            <ul className="navbar-nav ml-auto">
-					<li className="nav-item">
-	                    <a href={process.env.REACT_APP_LOGIN_URL} className="nav-link"><i className="nc-icon nc-button-power"></i>Let's get started</a>
-	                </li>
-					<li className="nav-item">
-                        <a className="nav-link" rel="tooltip" title="Follow us on Twitter" data-placement="bottom" href="http://google.com">
-                            <FontAwesomeIcon icon={["fab", "twitter"]} className="fa fa-twitter" />
-                            <p className="d-lg-none">Twitter</p>
-                        </a>
-                    </li>
-                    <li className="nav-item">
-                        <a className="nav-link" rel="tooltip" title="Like us on Facebook" data-placement="bottom" href="http://google.com">
-                            <FontAwesomeIcon icon={["fab", "facebook"]} className="fa fa-facebook-square"/>
-                            <p className="d-lg-none">Facebook</p>
-                        </a>
-                    </li>
-                    <li className="nav-item">
-                        <a className="nav-link" rel="tooltip" title="Follow us on Instagram" data-placement="bottom" href="http://google.com">
-                            <FontAwesomeIcon icon={["fab", "instagram"]} className="fa fa-instagram"/>
-                            <p className="d-lg-none">Instagram</p>
-                        </a>
-                    </li>
-                    <li className="nav-item">
-                        <a className="nav-link" rel="tooltip" title="Star on GitHub" data-placement="bottom" href="http://google.com">
-                            <FontAwesomeIcon icon={["fab", "github"]} className="fa fa-github"/>
-                            <p className="d-lg-none">GitHub</p>
-                        </a>
-                    </li>
-	            </ul>
-	        </div>
-		</div>
-    </nav>
-        
-    
-<div className="page-header computer" data-parallax="false" >
-    <div className="filter"></div>
-        <div className="container">
+  render() {
+    return (
+      <div>
+        <nav
+          className="navbar navbar-expand-lg fixed-top navbar-transparent"
+          color-on-scroll="300"
+        >
+          <div className="container">
+            <div className="navbar-translate">
+              <a className="navbar-brand" href="#">
+                Don't send that email
+              </a>
+              <button
+                className="navbar-toggler navbar-toggler-right navbar-burger"
+                type="button"
+                data-toggle="collapse"
+                data-target="#navbarToggler"
+                aria-controls="navbarTogglerDemo02"
+                aria-expanded="false"
+                aria-label="Toggle navigation"
+              >
+                <span className="navbar-toggler-bar" />
+                <span className="navbar-toggler-bar" />
+                <span className="navbar-toggler-bar" />
+              </button>
+            </div>
+            <div className="collapse navbar-collapse" id="navbarToggler">
+              <ul className="navbar-nav ml-auto">
+                <li className="nav-item">
+                  <a
+                    href={process.env.REACT_APP_BACKEND_URL + '/auth/login'}
+                    className="nav-link"
+                  >
+                    <i className="nc-icon nc-button-power" />Let's get started
+                  </a>
+                </li>
+                <li className="nav-item">
+                  <a
+                    className="nav-link"
+                    rel="tooltip"
+                    title="Follow us on Twitter"
+                    data-placement="bottom"
+                    href="http://google.com"
+                  >
+                    <FontAwesomeIcon
+                      icon={['fab', 'twitter']}
+                      className="fa fa-twitter"
+                    />
+                    <p className="d-lg-none">Twitter</p>
+                  </a>
+                </li>
+                <li className="nav-item">
+                  <a
+                    className="nav-link"
+                    rel="tooltip"
+                    title="Like us on Facebook"
+                    data-placement="bottom"
+                    href="http://google.com"
+                  >
+                    <FontAwesomeIcon
+                      icon={['fab', 'facebook']}
+                      className="fa fa-facebook-square"
+                    />
+                    <p className="d-lg-none">Facebook</p>
+                  </a>
+                </li>
+                <li className="nav-item">
+                  <a
+                    className="nav-link"
+                    rel="tooltip"
+                    title="Follow us on Instagram"
+                    data-placement="bottom"
+                    href="http://google.com"
+                  >
+                    <FontAwesomeIcon
+                      icon={['fab', 'instagram']}
+                      className="fa fa-instagram"
+                    />
+                    <p className="d-lg-none">Instagram</p>
+                  </a>
+                </li>
+                <li className="nav-item">
+                  <a
+                    className="nav-link"
+                    rel="tooltip"
+                    title="Star on GitHub"
+                    data-placement="bottom"
+                    href="http://google.com"
+                  >
+                    <FontAwesomeIcon
+                      icon={['fab', 'github']}
+                      className="fa fa-github"
+                    />
+                    <p className="d-lg-none">GitHub</p>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </nav>
+
+        <div className="page-header computer" data-parallax="false">
+          <div className="filter" />
+          <div className="container">
             <div className="motto text-center">
-                <h1>Don't send that email!</h1>
-                <h3>Save yourself the trouble of worrying about the tone of your emails.</h3>
-                <br />
+              <h1>Don't send that email!</h1>
+              <h3>
+                Save yourself the trouble of worrying about the tone of your
+                emails.
+              </h3>
+              <br />
             </div>
+          </div>
         </div>
-    </div>
-<div className="main">
-    <div className="section text-center">
-        <div className="container">
-            <div className="row">
-                <div className="col-md-8 ml-auto mr-auto">
-                    <h2 className="title">Let's talk product</h2>
-                    <h5 className="description">Our product can help you in many situations, want that job and need someone to ensure you give the proper tone or convey the right emotions? We got you covered. Working for a non-profit organization and need to bring awareness? We got you covered.</h5>
-                    <br/>
-                    <a href="#paper-kit" className="btn btn-danger btn-round">See Details</a>
-                </div>
-            </div>
-            <br/><br/>
-            <div className="row">
-                <div className="col-md-3">
-                    <div className="info">
-                        <div className="icon icon-danger">
-                            <i className="nc-icon nc-chat-33"></i>
-                        </div>
-                        <div className="description">
-                            <h4 className="info-title">Family and friends</h4>
-                            <p className="description">Our product can help you give the proper holiday wish or casual conversation.</p>
-                            <a href="#pkp" className="btn btn-link btn-danger">See more</a>
-                        </div>
-                    </div>
-                </div>
-                <div className="col-md-3">
-                    <div className="info">
-                        <div className="icon icon-danger">
-                            <i className="nc-icon nc-bulb-63"></i>
-                        </div>
-                        <div className="description">
-                            <h4 className="info-title">Intuitive</h4>
-                            <p>Help you catch the right emotions to ensure higher chances to convey what you want.</p>
-                            <a href="#pkp" className="btn btn-link btn-danger">See more</a>
-                        </div>
-                    </div>
-                </div>
-                <div className="col-md-3">
-                    <div className="info">
-                        <div className="icon icon-danger">
-                            <i className="nc-icon nc-email-85"></i>
-                        </div>
-                        <div className="description">
-                            <h4 className="info-title">Promotions</h4>
-                            <p>Our product can help you achieve.</p>
-                            <a href="#pkp" className="btn btn-link btn-danger">See more</a>
-                        </div>
-                    </div>
-                </div>
-                <div className="col-md-3">
-                    <div className="info">
-                        <div className="icon icon-danger">
-                            <i className="nc-icon nc-watch-time"></i>
-                        </div>
-                        <div className="description">
-                            <h4 className="info-title">Efficiency</h4>
-                            <p>Always in a hurry? We got you covered, One click away to prevent offensive emails.</p>
-                            <a href="#pkp" className="btn btn-link btn-danger">See more</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-        </div>
-    </div>
-
-    <div className="section section-dark text-center">
-        <div className="container">
-            <h2 className="title">Let's talk about us</h2>
-            <div className="row">
-                <div className="col-md-4">
-                    <div className="card card-profile card-plain">
-                        <div className="card-avatar">
-                            <a href="http://google.com">
-                                <img src="./assets/img/faces/thomas.jpg" alt="..."/>
-                            </a>
-                        </div>
-                        <div className="card-body">
-                            <a href="#paper-kit">
-                                <div className="author">
-                                    <h4 className="card-title">Thomas</h4>
-                                    <h6 className="card-category">Project Manager</h6>
-                                </div>
-                            </a>
-                            <p className="card-description text-center">
-                            Did you meet this week MVP yet?
-                            </p>
-                        </div>
-                        <div className="card-footer text-center">
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "twitter"]} className="fa fa-twitter" /></a>
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "google-plus-g"]} className="fa fa-google-plus"/></a>
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "linkedin-in"]} className="fa fa-linkedin" /></a>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="col-md-4">
-                    <div className="card card-profile card-plain">
-                        <div className="card-avatar">
-                            <a href="#avatar"><img src="./assets/img/faces/Fred.jpg" alt="..."/></a>
-                        </div>
-                        <div className="card-body">
-                            <a href="#paper-kit">
-                                <div className="author">
-                                    <h4 className="card-title">Fred</h4>
-                                    <h6 className="card-category">Designer</h6>
-                                </div>
-                            </a>
-                            <p className="card-description text-center">
-                            Hey.
-                            </p>
-                        </div>
-                        <div className="card-footer text-center">
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "twitter"]} className="fa fa-twitter" /></a>
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "google-plus-g"]} className="fa fa-google-plus"/></a>
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "linkedin-in"]} className="fa fa-linkedin" /></a>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="col-md-4">
-                    <div className="card card-profile card-plain">
-                        <div className="card-avatar">
-                            <a href="#avatar"><img src="./assets/img/faces/jared.jpg" alt="..."/></a>
-                        </div>
-                        <div className="card-body">
-                            <a href="#paper-kit">
-                                <div className="author">
-                                    <h4 className="card-title">Jared</h4>
-                                    <h6 className="card-category">Developer</h6>
-                                </div>
-                            </a>
-                            <p className="card-description text-center">
-                            We chose NodeJS because it is highly performant event-driven response cycle allows for high traffic.
-                            </p>
-                        </div>
-                        <div className="card-footer text-center">
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "twitter"]} className="fa fa-twitter" /></a>
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "google-plus-g"]} className="fa fa-google-plus"/></a>
-                            <a href="#pablo" className="btn btn-link btn-just-icon btn-neutral"><FontAwesomeIcon icon={["fab", "linkedin-in"]} className="fa fa-linkedin" /></a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-        <div className="section landing-section">
+        <div className="main">
+          <div className="section text-center">
             <div className="container">
-                <div className="row">
-                    <div className="col-md-8 ml-auto mr-auto">
-                        <h2 className="text-center">Keep in touch?</h2>
-                        <form className="contact-form">
-                            <div className="row">
-                                <div className="col-md-6">
-                                    <label>Name</label>
-                                    <div className="input-group">
-                                        <span className="input-group-addon">
-                                            <i className="nc-icon nc-single-02"></i>
-                                        </span>
-                                        <input type="text" className="form-control" placeholder="Name"/>
-                                    </div>
-                                </div>
-                                <div className="col-md-6">
-                                    <label>Email</label>
-                                    <div className="input-group">
-                                        <span className="input-group-addon">
-                                            <i className="nc-icon nc-email-85"></i>
-                                        </span>
-                                        <input type="text" className="form-control" placeholder="Email"/>
-                                    </div>
-                                </div>
-                            </div>
-                            <label>Message</label>
-                            <textarea className="form-control" rows="4" placeholder="Tell us your thoughts and feelings..."></textarea>
-                            <div className="row">
-                                <div className="col-md-4 ml-auto mr-auto">
-                                    <button className="btn btn-danger btn-lg btn-fill">Send Message</button>
-                                </div>
-                            </div>
-                        </form>
-                    </div>
+              <div className="row">
+                <div className="col-md-8 ml-auto mr-auto">
+                  <h2 className="title">Let's talk product</h2>
+                  <h5 className="description">
+                    Our product can help you in many situations, want that job
+                    and need someone to ensure you give the proper tone or
+                    convey the right emotions? We got you covered. Working for a
+                    non-profit organization and need to bring awareness? We got
+                    you covered.
+                  </h5>
+                  <br />
+                  <a href="#paper-kit" className="btn btn-danger btn-round">
+                    See Details
+                  </a>
                 </div>
+              </div>
+              <br />
+              <br />
+              <div className="row">
+                <div className="col-md-3">
+                  <div className="info">
+                    <div className="icon icon-danger">
+                      <i className="nc-icon nc-chat-33" />
+                    </div>
+                    <div className="description">
+                      <h4 className="info-title">Family and friends</h4>
+                      <p className="description">
+                        Our product can help you give the proper holiday wish or
+                        casual conversation.
+                      </p>
+                      <a href="#pkp" className="btn btn-link btn-danger">
+                        See more
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="info">
+                    <div className="icon icon-danger">
+                      <i className="nc-icon nc-bulb-63" />
+                    </div>
+                    <div className="description">
+                      <h4 className="info-title">Intuitive</h4>
+                      <p>
+                        Help you catch the right emotions to ensure higher
+                        chances to convey what you want.
+                      </p>
+                      <a href="#pkp" className="btn btn-link btn-danger">
+                        See more
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="info">
+                    <div className="icon icon-danger">
+                      <i className="nc-icon nc-email-85" />
+                    </div>
+                    <div className="description">
+                      <h4 className="info-title">Promotions</h4>
+                      <p>Our product can help you achieve.</p>
+                      <a href="#pkp" className="btn btn-link btn-danger">
+                        See more
+                      </a>
+                    </div>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="info">
+                    <div className="icon icon-danger">
+                      <i className="nc-icon nc-watch-time" />
+                    </div>
+                    <div className="description">
+                      <h4 className="info-title">Efficiency</h4>
+                      <p>
+                        Always in a hurry? We got you covered, One click away to
+                        prevent offensive emails.
+                      </p>
+                      <a href="#pkp" className="btn btn-link btn-danger">
+                        See more
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
+          </div>
+
+          <div className="section section-dark text-center">
+            <div className="container">
+              <h2 className="title">Let's talk about us</h2>
+              <div className="row">
+                <div className="col-md-4">
+                  <div className="card card-profile card-plain">
+                    <div className="card-avatar">
+                      <a href="http://google.com">
+                        <img src="./assets/img/faces/thomas.jpg" alt="..." />
+                      </a>
+                    </div>
+                    <div className="card-body">
+                      <a href="#paper-kit">
+                        <div className="author">
+                          <h4 className="card-title">Thomas</h4>
+                          <h6 className="card-category">Project Manager</h6>
+                        </div>
+                      </a>
+                      <p className="card-description text-center">
+                        Did you meet this week MVP yet?
+                      </p>
+                    </div>
+                    <div className="card-footer text-center">
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'twitter']}
+                          className="fa fa-twitter"
+                        />
+                      </a>
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'google-plus-g']}
+                          className="fa fa-google-plus"
+                        />
+                      </a>
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'linkedin-in']}
+                          className="fa fa-linkedin"
+                        />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="col-md-4">
+                  <div className="card card-profile card-plain">
+                    <div className="card-avatar">
+                      <a href="#avatar">
+                        <img src="./assets/img/faces/Fred.jpg" alt="..." />
+                      </a>
+                    </div>
+                    <div className="card-body">
+                      <a href="#paper-kit">
+                        <div className="author">
+                          <h4 className="card-title">Fred</h4>
+                          <h6 className="card-category">Designer</h6>
+                        </div>
+                      </a>
+                      <p className="card-description text-center">Hey.</p>
+                    </div>
+                    <div className="card-footer text-center">
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'twitter']}
+                          className="fa fa-twitter"
+                        />
+                      </a>
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'google-plus-g']}
+                          className="fa fa-google-plus"
+                        />
+                      </a>
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'linkedin-in']}
+                          className="fa fa-linkedin"
+                        />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="col-md-4">
+                  <div className="card card-profile card-plain">
+                    <div className="card-avatar">
+                      <a href="#avatar">
+                        <img src="./assets/img/faces/jared.jpg" alt="..." />
+                      </a>
+                    </div>
+                    <div className="card-body">
+                      <a href="#paper-kit">
+                        <div className="author">
+                          <h4 className="card-title">Jared</h4>
+                          <h6 className="card-category">Developer</h6>
+                        </div>
+                      </a>
+                      <p className="card-description text-center">
+                        We chose NodeJS because it is highly performant
+                        event-driven response cycle allows for high traffic.
+                      </p>
+                    </div>
+                    <div className="card-footer text-center">
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'twitter']}
+                          className="fa fa-twitter"
+                        />
+                      </a>
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'google-plus-g']}
+                          className="fa fa-google-plus"
+                        />
+                      </a>
+                      <a
+                        href="#pablo"
+                        className="btn btn-link btn-just-icon btn-neutral"
+                      >
+                        <FontAwesomeIcon
+                          icon={['fab', 'linkedin-in']}
+                          className="fa fa-linkedin"
+                        />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="section landing-section">
+            <div className="container">
+              <div className="row">
+                <div className="col-md-8 ml-auto mr-auto">
+                  <h2 className="text-center">Keep in touch?</h2>
+                  <form className="contact-form">
+                    <div className="row">
+                      <div className="col-md-6">
+                        <label>Name</label>
+                        <div className="input-group">
+                          <span className="input-group-addon">
+                            <i className="nc-icon nc-single-02" />
+                          </span>
+                          <input
+                            type="text"
+                            className="form-control"
+                            placeholder="Name"
+                          />
+                        </div>
+                      </div>
+                      <div className="col-md-6">
+                        <label>Email</label>
+                        <div className="input-group">
+                          <span className="input-group-addon">
+                            <i className="nc-icon nc-email-85" />
+                          </span>
+                          <input
+                            type="text"
+                            className="form-control"
+                            placeholder="Email"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <label>Message</label>
+                    <textarea
+                      className="form-control"
+                      rows="4"
+                      placeholder="Tell us your thoughts and feelings..."
+                    />
+                    <div className="row">
+                      <div className="col-md-4 ml-auto mr-auto">
+                        <button className="btn btn-danger btn-lg btn-fill">
+                          Send Message
+                        </button>
+                      </div>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-    </div> 
-</div> 
-    
-      );
-    }
+      </div>
+    );
   }
+}
 
 export default LandingPage;

--- a/client/src/components/emailcreate/Analysis.js
+++ b/client/src/components/emailcreate/Analysis.js
@@ -24,7 +24,7 @@ const Analysis = (props) => {
         {props.toneAnalysis.document_tone.tones.map((e, i) => {
           return (
             <p key={i}>
-              {e.tone_id}: {(e.score * 100).toFixed(2) + '%'}
+              {e.tone_id}: {(e.score * 100).toFixed() + '%'}
             </p>
           );
         })}

--- a/client/src/components/emailcreate/Analysis.js
+++ b/client/src/components/emailcreate/Analysis.js
@@ -2,19 +2,27 @@ import React from 'react';
 
 const Analysis = props => {
   console.log (props.error);
-  if (props.toneAnalysis === null) {
+  console.log (props.toneAnalysis);
+  if (props.error == 'Error: Request failed with status code 429') {
     return (
       <div>
-        <p>No analysis. Click the Analyze Button</p>
+        <p>Free users are capped at 100 email analyses.</p>
       </div>
     );
   } else if (
-    props.toneAnalysis.document_tone.tones.length === 0 ||
-    props.error
+    (props.toneAnalysis &&
+      props.toneAnalysis.document_tone.tones.length === 0) ||
+    props.error == 'Error: Request failed with status code 500'
   ) {
     return (
       <div>
         <p>The document does not have a tone to it.</p>
+      </div>
+    );
+  } else if (props.toneAnalysis === null) {
+    return (
+      <div>
+        <p>No analysis. Click the Analyze Button</p>
       </div>
     );
   } else {

--- a/client/src/components/emailcreate/Analysis.js
+++ b/client/src/components/emailcreate/Analysis.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Analysis = (props) => {
-  console.log(props.toneAnalysis);
+const Analysis = props => {
+  console.log (props.error);
   if (props.toneAnalysis === null) {
     return (
       <div>
@@ -21,10 +21,10 @@ const Analysis = (props) => {
     return (
       <div>
         <p>Document tones:</p>
-        {props.toneAnalysis.document_tone.tones.map((e, i) => {
+        {props.toneAnalysis.document_tone.tones.map ((e, i) => {
           return (
             <p key={i}>
-              {e.tone_id}: {(e.score * 100).toFixed() + '%'}
+              {e.tone_id}: {(e.score * 100).toFixed () + '%'}
             </p>
           );
         })}

--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -115,7 +115,7 @@ class NewEmail extends Component {
     axios
       .post(
         process.env.REACT_APP_BACKEND_URL + '/api/watson',
-        { text: this.selectedVersion().text },
+        { text: this.selectedVersion().text, reqType:'analyze'},
         { withCredentials: true }
       )
       .then((res) => {

--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -147,7 +147,7 @@ class NewEmail extends Component {
 
     try {
       const { data: { id } } = await axios.post(
-        process.env.REACT_APP_EMAILS_URL,
+        process.env.REACT_APP_BACKEND_URL + '/emails',
         body,
         headers
       );

--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -17,6 +17,7 @@ class NewEmail extends Component {
     versions: [{text: '', tone_analysis: null}],
     selected_version: 1,
     makingCall: false,
+    error: false,
   };
 
   componentDidMount () {
@@ -126,7 +127,7 @@ class NewEmail extends Component {
             versions[this.state.selected_version - 1].tone_analysis = res.data;
             this.setState ({versions, error: false, makingCall: false});
           })
-          .catch (err => this.setState ({error: true, makingCall: false}));
+          .catch (err => this.setState ({error: err, makingCall: false}));
       });
     }
   };

--- a/server/middlewares/populateUser.js
+++ b/server/middlewares/populateUser.js
@@ -54,17 +54,18 @@ const populateUser = async (req, res, next) => {
         }
         if (verified === 1) {
           next ();
+        } else {
+          throw 'Request failed with status code 429';
         }
       }
     } else {
       next ();
     }
   } catch (err) {
-    if (req.body.reqType === 'analyze') {
-      res.status (429).json ({err});
+    if (err == 'Request failed with status code 429') {
+      res.status (429).json (err);
     } else {
-      res.status (500).json ({err});
-      throw err;
+      res.status (500).json (err);
     }
   }
 };

--- a/server/middlewares/populateUser.js
+++ b/server/middlewares/populateUser.js
@@ -1,43 +1,83 @@
-const moment = require('moment');
-const db = require('../data/dbconfig');
-
+const moment = require ('moment');
+const db = require ('../data/dbconfig');
+const month = 2628000000;
 const populateUser = async (req, res, next) => {
   if (!req.user) {
-    return res.status(400).json({ err: 'No user logged in.' });
+    return res.status (400).json ({err: 'No user logged in.'});
   }
 
   try {
     // Look up user in db using email address from session
     const emailaddress = req.user.emails[0].value;
-    const users = await db('users').where({ emailaddress });
+    const users = await db ('users').where ({emailaddress});
     req.user = users[0];
 
     // Look up the latest subscription for the user
-    const subscription = await db('subscriptions')
-      .where({ user_id: req.user.id })
-      .orderBy('date_created', 'desc')
-      .first();
+    const subscription = await db ('subscriptions')
+      .where ({user_id: req.user.id})
+      .orderBy ('date_created', 'desc')
+      .first ();
     if (subscription) {
-      req.user.subscribed = isSubscriptionActive(subscription);
+      req.user.subscribed = isSubscriptionActive (subscription);
     }
-
-    console.log('[populateUser] - found ', req.user);
-    next();
+    console.log ('[populateUser] - found ', req.user);
+    if (req.body.reqType === 'analyze') {
+      if (req.user.subscribed) {
+        next ();
+      } else {
+        let verified;
+        if (
+          req.user.currentCycleStart === null &&
+          req.user.analysesCount === null
+        ) {
+          verified = await db ('users')
+            .where ({id: req.user.id})
+            .update ({analysesCount: 1, currentCycleStart: Date.now ()});
+        } else {
+          if (req.user.analysesCount < 100) {
+            if (Date.now () - req.user.currentCycleStart >= month) {
+              verified = await db ('users')
+                .where ({id: req.user.id})
+                .update ({analysesCount: 1, currentCycleStart: Date.now ()});
+            } else {
+              verified = await db ('users')
+                .where ({id: req.user.id})
+                .update ({analysesCount: req.user.analysesCount + 1});
+            }
+          } else {
+            if (Date.now () - req.user.currentCycleStart >= month) {
+              verified = await db ('users')
+                .where ({id: req.user.id})
+                .update ({analysesCount: 1, currentCycleStart: Date.now ()});
+            }
+          }
+        }
+        if (verified === 1) {
+          next ();
+        }
+      }
+    } else {
+      next ();
+    }
   } catch (err) {
-    res.status(500).json({ err });
-    throw err;
+    if (req.body.reqType === 'analyze') {
+      res.status (429).json ({err});
+    } else {
+      res.status (500).json ({err});
+      throw err;
+    }
   }
 };
 
-const isSubscriptionActive = (subscription) => {
+const isSubscriptionActive = subscription => {
   // Force moment to treat datestring from the database as UTC
   // TODO: fix this in the knex configuration
   const datestring = subscription.date_created + '+0000';
 
   // Check to see if user is within the subscription window
-  const start = moment(datestring);
-  const end = moment(datestring).add(subscription.duration, 'days');
-  return moment().isBetween(start, end);
+  const start = moment (datestring);
+  const end = moment (datestring).add (subscription.duration, 'days');
+  return moment ().isBetween (start, end);
 };
 
 module.exports = populateUser;


### PR DESCRIPTION
# Description

Added logic in populateUser middleware to limit the number of analyzes a free user can do it in a span of a month.  Also, added error to state in emailcreate index.js in order to render different views based on error message in analysis.js.  The render paths based on errors being that there is no document tone to a piece of text or that the user has requested too many times in a span of a given month (error code 429).  Also added a makingCall boolean index.js emailcreate which is used in analyseText function in order to guarantee 1 request is one update.  Noticed that without this there are times when a user can send two requests and only get 1 increment for analysesCount.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in browser and terminal

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
