### PR TITLE
Sidebar Home Remove Outline

### DIFF
--- a/client/src/components/Navigation/sideBar.css
+++ b/client/src/components/Navigation/sideBar.css
@@ -28,6 +28,11 @@ body {
   transition: color 0.2s;
 }
 
+/* Remove blue outline when clicked */
+.bm-item:focus, .bm-item:active {
+  outline: none;
+}
+
 .bm-item button {
   width: 100%;
   margin-left: -3px;
@@ -58,6 +63,12 @@ body {
   right: 30px;
   top: 10px;
 }
+
+/* Remove blue outline when clicked */
+/* .bm-burger-button:focus, .bm-burger-button:active {
+  outline: none !important;
+  box-shadow: none;
+} */
 
 /* Color/shape of burger icon bars */
 .bm-burger-bars {

--- a/client/src/components/Navigation/sideBar.css
+++ b/client/src/components/Navigation/sideBar.css
@@ -57,7 +57,6 @@ body {
 /* Position and sizing of burger button */
 .bm-burger-button {
   position: fixed;
-
   width: 36px;
   height: 30px;
   right: 30px;
@@ -65,10 +64,9 @@ body {
 }
 
 /* Remove blue outline when clicked */
-/* .bm-burger-button:focus, .bm-burger-button:active {
-  outline: none !important;
-  box-shadow: none;
-} */
+.bm-burger-button button:focus, .bm-burger-button button:active {
+  outline: none;
+}
 
 /* Color/shape of burger icon bars */
 .bm-burger-bars {

--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -15,12 +15,10 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import BreadCrumb from "../BreadCrumb";
 import Sidebar from "../Navigation/Sidebar";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "react-router-dom";
 import Editor from "./Editor";
 import Analysis from "./Analysis";
 import "./email.css";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 class NewEmail extends Component {
   crumbs = [{ name: "Home", path: "/" }, { name: "Document" }];


### PR DESCRIPTION
# Description

When the hamburger menu was clicked, the hamburger menu and the home button on the sidebar would have a blue outline. They were removed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Locally tested

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
