### PR TITLE
Analyze Parentheses Bug

### DIFF
--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -107,10 +107,11 @@ class NewEmail extends Component {
           Analytical: "primary",
           Tentative: "warning",
         };
+        text = text.replace(/[()]/g,''); // Removes parentheses from text
         tone_analysis.sentences_tone
           .filter(({ tones }) => tones.length) // Ignore sentences with no tones
           .forEach(({ text: sentence, tones }) => {
-            const re = new RegExp(sentence.trim()); // No leading or trailing whitespace in highlights
+            const re = new RegExp(sentence.replace(/[()]/g,'').trim()); // No leading or trailing whitespace in highlights. Replace removes parentheses from sentence
             const color = colors[tones[0].tone_name]; // Currently selects the first tone, not necessarily the best/strongest
             text = text.replace(re, (match) => {
               console.log("Matched");


### PR DESCRIPTION
# Description

Analyze didn't work if there was a stray parentheses in the text. I removed the parentheses when analyzing, and the parentheses return when looking at the card again. Not sure how to do it if the user does want parentheses in the analysis.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Locally tested

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
