### PR TITLE
Group by fix

### DIFF
--- a/client/src/components/DocumentList/index.js
+++ b/client/src/components/DocumentList/index.js
@@ -92,11 +92,15 @@ class DocumentList extends Component {
       })
       .catch(err => console.log(err));
   };
-  copyEmail = ({ title, addressee }) => e => {
+
+  copyEmail = ({ title, addressee, text }) => e => {
+
     if (this.props.user.subscribed === true || this.state.emails.length < 5) {
       console.log(this.props.user.subscribed);
-      const body = { email: { title, addressee } };
-      console.log(body);
+      text = text || ""
+      const version = { text }
+      const body = { email: { title, addressee }, version: version };
+      console.log(body)
       axios
         .post(process.env.REACT_APP_BACKEND_URL + "/emails", body, {
           withCredentials: true

--- a/server/routers/emails.js
+++ b/server/routers/emails.js
@@ -81,7 +81,6 @@ router.get("/", async (req, res) => {
   const emails = await db("emails")
     .leftJoin("versions", "versions.email_id", "emails.id")
     .orderBy("versions.date_created", "desc")
-    //.groupBy("emails.id", "versions.date_created, versions.text")
     .where({ "emails.user_id": req.user.id })
     .select(
       "emails.id",

--- a/server/routers/emails.js
+++ b/server/routers/emails.js
@@ -79,7 +79,7 @@ router.get("/:id", async (req, res) => {
 
 router.get("/", async (req, res) => {
   const emails = await db("emails")
-    .leftJoin("versions", "versions.email_id", "emails.id")
+    .leftOuterJoin("versions", "versions.email_id", "emails.id")
     .orderBy("versions.date_created", "desc")
     .where({ "emails.user_id": req.user.id })
     .select(

--- a/server/routers/emails.js
+++ b/server/routers/emails.js
@@ -81,7 +81,7 @@ router.get("/", async (req, res) => {
   const emails = await db("emails")
     .leftJoin("versions", "versions.email_id", "emails.id")
     .orderBy("versions.date_created", "desc")
-    .groupBy("emails.id", "versions.date_created, versions.text")
+    //.groupBy("emails.id", "versions.date_created, versions.text")
     .where({ "emails.user_id": req.user.id })
     .select(
       "emails.id",

--- a/server/routers/emails.js
+++ b/server/routers/emails.js
@@ -81,7 +81,7 @@ router.get("/", async (req, res) => {
   const emails = await db("emails")
     .leftJoin("versions", "versions.email_id", "emails.id")
     .orderBy("versions.date_created", "desc")
-    .groupBy("emails.id", "versions.date_created")
+    .groupBy("emails.id", "versions.date_created, versions.text")
     .where({ "emails.user_id": req.user.id })
     .select(
       "emails.id",

--- a/server/routers/emails.js
+++ b/server/routers/emails.js
@@ -81,7 +81,7 @@ router.get("/", async (req, res) => {
   const emails = await db("emails")
     .leftJoin("versions", "versions.email_id", "emails.id")
     .orderBy("versions.date_created", "desc")
-    .groupBy("emails.id")
+    .groupBy("emails.id", "versions.date_created")
     .where({ "emails.user_id": req.user.id })
     .select(
       "emails.id",

--- a/server/routers/emails.js
+++ b/server/routers/emails.js
@@ -79,8 +79,7 @@ router.get("/:id", async (req, res) => {
 
 router.get("/", async (req, res) => {
   const emails = await db("emails")
-    .leftOuterJoin("versions", "versions.email_id", "emails.id")
-    .orderBy("versions.date_created", "desc")
+    .leftJoin("versions", "versions.email_id", "emails.id")
     .where({ "emails.user_id": req.user.id })
     .select(
       "emails.id",
@@ -89,6 +88,26 @@ router.get("/", async (req, res) => {
       "versions.date_created as updated",
       "versions.text as text"
     )
+    // Postgres doesn't like groupBy, so we will group them ourselves
+    .then(emails => {
+      // Convert the list of emails into a hashtable indexed by email ID
+      const hashed = {};
+      emails.forEach(email => {
+        if (!hashed[email.id]) {
+          hashed[email.id] = email;
+        } else {
+          // Replace the existing entry if the associated version is newer
+          const updated = moment(email.updated);
+          const hashed_updated = moment(hashed[email.id].updated);
+          if (updated.isAfter(hashed_updated)) {
+            hashed[email.id] = email;
+          }
+        }
+      });
+      // Return a list of emails
+      return Object.values(hashed);
+    })
+    // Convert database dates into something readable
     .then(emails => emails.map(processEmail));
   res.json({ emails });
 });


### PR DESCRIPTION
# Description

Fixes # (issue)
  This fixes two issues. When duplicating an email there was a bug that crashed it when clicking on the duplicate.
Second, there was a `groupBy` in the sql query. That didn't allow showing the list of emails.
@jcuffe and I worked on this.
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Change status
- [ ] Complete, tested, ready to review and merge
- [X] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
  Tested manually.

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
