### PR TITLE
Reduce hamburger button

### DIFF
--- a/client/src/components/Navigation/sideBar.css
+++ b/client/src/components/Navigation/sideBar.css
@@ -56,8 +56,8 @@ body {
 /* Position and sizing of burger button */
 .bm-burger-button {
   position: absolute;
-  width: 36px;
-  height: 30px;
+  width: 24px;
+  height: 18px;
   right: 50px;
   top: 20px;
 }
@@ -66,10 +66,10 @@ body {
 @media (min-width: 320px) {
   .bm-burger-button {
     position: absolute;
-    width: 36px;
-    height: 30px;
+    width: 30px;
+    height: 24px;
     right: 15px;
-    top: 20px;
+    top: 25px;
   }
 }
 
@@ -77,10 +77,10 @@ body {
 @media (min-width: 360px) {
   .bm-burger-button {
     position: absolute;
-    width: 36px;
-    height: 30px;
+    width: 24px;
+    height: 18px;
     right: 15px;
-    top: 20px;
+    top: 25px;
   }
 }
 
@@ -89,10 +89,10 @@ body {
 @media (min-width: 375px) {
   .bm-burger-button {
     position: absolute;
-    width: 36px;
-    height: 30px;
+    width: 24px;
+    height: 18px;
     right: 15px;
-    top: 20px;
+    top: 25px;
   }
 }
 
@@ -103,7 +103,7 @@ body {
     width: 36px;
     height: 30px;
     right: 15px;
-    top: 20px;
+    top: 25px;
   }
 }
 
@@ -111,10 +111,10 @@ body {
 @media (min-width: 414px) {
   .bm-burger-button {
     position: absolute;
-    width: 36px;
-    height: 30px;
+    width: 24px;
+    height: 18px;
     right: 15px;
-    top: 20px;
+    top: 25px;
   }
 }
 
@@ -123,8 +123,8 @@ body {
 @media (min-width: 768px) {
   .bm-burger-button {
     position: absolute;
-    width: 36px;
-    height: 30px;
+    width: 24px;
+    height: 18px;
     right: 50px;
     top: 20px;
   }
@@ -134,8 +134,8 @@ body {
 @media (min-width: 1024px) {
   .bm-burger-button {
     position: absolute;
-    width: 36px;
-    height: 30px;
+    width: 24px;
+    height: 18px;
     right: 55px;
     top: 20px;
   }

--- a/client/src/components/Navigation/sideBar.css
+++ b/client/src/components/Navigation/sideBar.css
@@ -59,15 +59,15 @@ body {
   width: 24px;
   height: 18px;
   right: 50px;
-  top: 20px;
+  top: 25px;
 }
 
 /* Iphone 5/SE hamburger position */
 @media (min-width: 320px) {
   .bm-burger-button {
     position: absolute;
-    width: 30px;
-    height: 24px;
+    width: 24px;
+    height: 18px;
     right: 15px;
     top: 25px;
   }
@@ -126,7 +126,7 @@ body {
     width: 24px;
     height: 18px;
     right: 50px;
-    top: 20px;
+    top: 25px;
   }
 }
 
@@ -137,7 +137,7 @@ body {
     width: 24px;
     height: 18px;
     right: 55px;
-    top: 20px;
+    top: 25px;
   }
 }
 


### PR DESCRIPTION
# Description
 As per Bri's suggestion. I've shrunk the hamburger menu. It's about 6 pixels smaller on the height and width.
I also increased it's distance from the top by 5 pixels.
HOWEVER, this causes a conflict with the greeting text. They overlap when the device is around 472px wide.

So we need to fix that.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Change status
- [ ] Complete, tested, ready to review and merge
- [X] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
  Visual inspection in chrome browser.

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
