### PR TITLE
We have bold and white text in the analyzed sentences

### DIFF
--- a/client/src/components/emailcreate/email.css
+++ b/client/src/components/emailcreate/email.css
@@ -3,6 +3,11 @@
   width: 100%;
 }
 
+  .analyzed {
+    font-weight: bold;
+    color: white;
+  }
+
   .navbar {
     margin-bottom: 0;
     border-radius: 0;
@@ -37,3 +42,4 @@
     color: white;
     padding: 15px;
   }
+

--- a/client/src/components/emailcreate/index.js
+++ b/client/src/components/emailcreate/index.js
@@ -128,7 +128,7 @@ class NewEmail extends Component {
             const color = colors[tones[0].tone_name]; // Currently selects the first tone, not necessarily the best/strongest
             text = text.replace(re, match => {
               console.log("Matched");
-              return `<span class="label-${color}">${match}</span>`;
+              return `<span class="label-${color} analyzed">${match}</span>`;
             });
             console.log(text);
           });


### PR DESCRIPTION
# Description
  Bri suggested bold and white text after Watson analyzes the text. So that works now. 
  It just required adding an `analyzed` class to the css file. Then adding it to the `span` class after the text is analyzed.

Fixes # (issue)
NA
## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


## Change status
- [ ] Complete, tested, ready to review and merge
- [X] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
  Tested manually in a Chrome browser.


- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
