### PR TITLE
Refactors email create endpoint to accurately persist version dates.

### DIFF
--- a/server/routers/emails.js
+++ b/server/routers/emails.js
@@ -15,15 +15,21 @@ router.post("/", async (req, res) => {
     email.user_id = req.user.id;
     if (email.id) {
       const { title, addressee, id } = email;
-      await db("emails").where({ id }).update({ title, addressee });
+      await db("emails")
+        .where({ id })
+        .update({ title, addressee });
       console.log("had an id", id);
     } else {
-      email.id = (await db("emails").insert(email).returning("id"))[0];
+      email.id = (await db("emails")
+        .insert(email)
+        .returning("id"))[0];
       console.log("made a new id", email.id);
     }
 
     if (version) {
-      delete version.id; // For saving a new copy of an edited version
+      // Remove unnecessary fields
+      delete version.id;
+      delete version.date_created;
       version.email_id = email.id;
       console.log("inserting version with email_id: ", version.email_id);
       version.tone_analysis = JSON.stringify(version.tone_analysis);
@@ -39,28 +45,36 @@ router.post("/", async (req, res) => {
 
 router.delete("/:id", async (req, res) => {
   const { id } = req.params;
-  await db("versions").where({ email_id: id }).del();
-  const count = await db("emails").where({ id }).del();
+  await db("versions")
+    .where({ email_id: id })
+    .del();
+  const count = await db("emails")
+    .where({ id })
+    .del();
   res.json({ count });
 });
 
 router.get("/:id", async (req, res) => {
   const { id } = req.params;
-  const email = await db("emails").where({ id }).first();
+  const email = await db("emails")
+    .where({ id })
+    .first();
   // Fetch all versions, and parse their tone analyses
-  email.versions = await db("versions").where({ email_id: id }).then(vs => {
-    console.log(`versions for email ${id}`);
-    return vs.map(v => {
-      console.log("versiondata:");
-      console.log(v.tone_analysis);
-      // Postgres will give us an already-parsed JSON object, but SQLite will not
-      try {
-        v.tone_analysis = JSON.parse(v.tone_analysis);
-      } finally {
-        return v;
-      }
+  email.versions = await db("versions")
+    .where({ email_id: id })
+    .then(vs => {
+      console.log(`versions for email ${id}`);
+      return vs.map(v => {
+        console.log("versiondata:");
+        console.log(v.tone_analysis);
+        // Postgres will give us an already-parsed JSON object, but SQLite will not
+        try {
+          v.tone_analysis = JSON.parse(v.tone_analysis);
+        } finally {
+          return v;
+        }
+      });
     });
-  });
   res.json({ email });
 });
 
@@ -80,12 +94,14 @@ router.get("/", async (req, res) => {
       // Convert the list of emails into a hashtable indexed by email ID
       const hashed = {};
       emails.forEach(email => {
+        console.log(email);
         if (!hashed[email.id]) {
           hashed[email.id] = email;
         } else {
           // Replace the existing entry if the associated version is newer
           const updated = moment(email.updated);
           const hashed_updated = moment(hashed[email.id].updated);
+          // console.log(hashed_updated, updated, email.text);
           if (updated.isAfter(hashed_updated)) {
             hashed[email.id] = email;
           }


### PR DESCRIPTION
# Description

Previously, the back end was using the existing version object from the client to persist a new version. The creation date was not being removed from the original data, so all versions after the first had identical creation dates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Manually, locally.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
