### PR TITLE
Fixed the links to the API instruction docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ To clone the app to your local machine, follow these instructions.
 
 5. You will need to make three accounts for three keys. See below on how to get these keys.
   * [IBM Watson Tone Analysis API key](docs/watson_key_instructions.md)
-  * [The Stripe key](stripe_instructions.md)
-  * [Auth0 key](docs/auth0.md)
+  * [The Stripe key](docs/stripe.md)
+  * [Auth0 key](docs/Auth0/README.md)
 
 6. In the `server` directory you need to get Knex. It's a library we use to manage our databases.
   Get it by typing `npm install knex`. This will install knex so you can install the database.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ To clone the app to your local machine, follow these instructions.
 
 
 5. You will need to make three accounts for three keys. See below on how to get these keys.
-  * [IBM Watson Tone Analysis API key](docs/watson_key_instructions.md)
-  * [The Stripe key](docs/stripe.md)
+  * [IBM Watson Tone Analysis API key](docs/watson/README.md)
+  * [The Stripe key](docs/stripe/README.md)
   * [Auth0 key](docs/Auth0/README.md)
 
 6. In the `server` directory you need to get Knex. It's a library we use to manage our databases.


### PR DESCRIPTION
# Description
Adds correct links to the Auth0 API instructions and the Stripe API instructions.

Fixes # (issue)
 Broken link on `README`
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?
  Visual inspection in the README

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
