### PR TITLE
Greeting and Hamburger Spacing

### DIFF
--- a/client/src/components/Navigation/Sidebar.js
+++ b/client/src/components/Navigation/Sidebar.js
@@ -60,7 +60,7 @@ export default class Sidebar extends Component {
             </Button>
           </a>
         </Menu>
-        {/* <FontAwesomeIcon onClick={() => this.toggleMenu()} icon="times" /> */}
+        {/* Hamburger */}
         <button className={classes} onClick={this.toggleMenu} type="button">
           <span className="hamburger-box">
             <span className="hamburger-inner" />

--- a/client/src/components/Navigation/hamburger.css
+++ b/client/src/components/Navigation/hamburger.css
@@ -70,8 +70,8 @@
   @media (min-width: 411px) {
     .hamburger {
       position: absolute;
-      width: 36px;
-      height: 30px;
+      width: 24px;
+      height: 18px;
       right: 15px;
       top: 25px;
     }

--- a/client/src/components/Navigation/index.css
+++ b/client/src/components/Navigation/index.css
@@ -16,7 +16,13 @@
 @media (max-width: 1024px) {
     .nav {
         margin-left: auto;
-        margin-right: 45px;
+        margin-right: 60px;
+    }
+}
+
+@media (max-width: 1290px) {
+    .nav {
+        margin-right: 30px;
     }
 }
 
@@ -27,6 +33,7 @@
     vertical-align: text-bottom;
 }
 
-nav ul li .nav-item {
+nav .nav-item {
     color: null;
+    margin-right: 20px;
 }


### PR DESCRIPTION
# Description

Added more space between the greeting and hamburger so they don't overlap when shrinking the screen.

Fixes # (issue)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Locally run

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
