### PR TITLE
Remove hamburger menu cross, center buttons and text spans

### DIFF
--- a/client/src/components/Navigation/Sidebar.js
+++ b/client/src/components/Navigation/Sidebar.js
@@ -36,6 +36,7 @@ export default class Sidebar extends Component {
       <div>
         <Menu
           customBurgerIcon={ false }
+          customCrossIcon={ false }
           isOpen={this.state.menuOpen}
           onStateChange={state => this.handleStateChange(state)}
           right
@@ -50,7 +51,7 @@ export default class Sidebar extends Component {
           <Link to="/profile">
             <Button color="danger">
               <FontAwesomeIcon icon="user" />
-              <span>Profile</span>
+              <span className="middle-button">Profile</span>
             </Button>
           </Link>
           <a href={this.logoutUrl}>

--- a/client/src/components/Navigation/sideBar.css
+++ b/client/src/components/Navigation/sideBar.css
@@ -44,6 +44,11 @@ body {
 .bm-item button span {
   width: 70%;
   text-align: left;
+  margin-left: 6em;
+}
+
+.bm-item button .middle-button {
+  margin-left: 6.25em;
 }
 
 /* Change color on hover */
@@ -179,7 +184,7 @@ body {
 /* General sidebar styles */
 .bm-menu {
   background: #fff;
-  padding: 2.5em 1.5em 0;
+  padding: 1em 1em 0;
   font-size: 1.15em;
   overflow: hidden !important;
 }
@@ -192,6 +197,7 @@ body {
 /* Wrapper for item list */
 .bm-item-list {
   color: #b8b7ad;
+  margin-left: 0.35em;
 }
 
 /* Styling of overlay */


### PR DESCRIPTION
# Description

Removed the grey cross icon in the hamburger menu. Made the hamburger menu buttons centered and fill out the menu more width-wise. Centered the Home, Profile, and Sign out text.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Locally checked

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
