### PR TITLE
 Set max length

### DIFF
--- a/client/src/components/Billing/index.js
+++ b/client/src/components/Billing/index.js
@@ -25,7 +25,7 @@ class Billing extends Component {
           </Col>
           <Col xs={12}>
             <Card className="no-transition">
-              <CardHeader>Paid User Privileges</CardHeader>
+              <CardHeader>Premium User Privileges</CardHeader>
               <CardBody>
                 <ul>
                   <li>

--- a/client/src/components/DocumentList/Document.js
+++ b/client/src/components/DocumentList/Document.js
@@ -28,10 +28,14 @@ class Document extends Component {
         <CardBody>
           <CardTitle>
             <Row>
-              <Col xs={12} style={{ marginBottom: 3 }}>
+              <Col
+                xs={12}
+                style={{ marginBottom: 3 }}
+                className="text-truncate"
+              >
                 <Badge className="titleBadge">Title</Badge> {title}
               </Col>
-              <Col xs={12}>
+              <Col xs={12} className="text-truncate">
                 <Badge className="addresseeBadge">Addressee</Badge> {addressee}
               </Col>
               {updated !== "No versions." && (
@@ -60,7 +64,6 @@ class Document extends Component {
                 }}
               >
                 <FontAwesomeIcon icon="copy" />
-
               </Button>
               <Button
                 color="danger"

--- a/client/src/components/DocumentList/index.css
+++ b/client/src/components/DocumentList/index.css
@@ -7,8 +7,8 @@
   .textBadge,
   .updatedBadge,
   .addresseeBadge {
-    width: 18%;
-    margin-right: 2%;
+    width: 25%;
+    margin-right: 3%;
     text-align: center;
   }
 }
@@ -17,8 +17,8 @@
   .textBadge,
   .updatedBadge,
   .addresseeBadge {
-    width: 12.5%;
-    margin-right: 2%;
+    width: 15%;
+    margin-right: 3%;
     text-align: center;
   }
 }
@@ -41,13 +41,6 @@
 @media (min-width: 1200px) {
   .card-columns {
     column-count: 2 !important;
-  }
-  .titleBadge,
-  .textBadge,
-  .updatedBadge,
-  .addresseeBadge {
-    width: 13%;
-    text-align: center;
   }
 }
 

--- a/client/src/components/Profile/index.js
+++ b/client/src/components/Profile/index.js
@@ -5,12 +5,8 @@ import Billing from "../Billing";
 import "./index.css";
 
 const Profile = props => {
-
   return (
     <Container className="mt-3">
-      <Row>
-        <Col xs={12} />
-      </Row>
       <Row>
         <Col xs={12} md={6}>
           <Settings user={props.user} />
@@ -21,6 +17,5 @@ const Profile = props => {
       </Row>
     </Container>
   );
-
 };
 export default Profile;

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -28,10 +28,6 @@ const Settings = props => {
                   {props.user.username}
                 </Col>
                 <Col xs={12} style={{ marginBottom: 3 }}>
-                  <Badge className="emailBadge">Email</Badge>{" "}
-                  {props.user.emailaddress}
-                </Col>
-                <Col xs={12} style={{ marginBottom: 3 }}>
                   <Badge className="tierBadge">Tier</Badge>{" "}
                   {props.user.subscribed ? "Paid" : "Free"}
                 </Col>

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -28,6 +28,10 @@ const Settings = props => {
                   {props.user.username}
                 </Col>
                 <Col xs={12} style={{ marginBottom: 3 }}>
+                  <Badge className="emailBadge">Email</Badge>{" "}
+                  {props.user.emailaddress}
+                </Col>
+                <Col xs={12} style={{ marginBottom: 3 }}>
                   <Badge className="tierBadge">Tier</Badge>{" "}
                   {props.user.subscribed ? "Paid" : "Free"}
                 </Col>

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -24,7 +24,7 @@ const Settings = props => {
             <CardBody>
               <Row>
                 <Col xs={12} style={{ marginBottom: 3 }}>
-                  <Badge className="userBadge">Username</Badge>{" "}
+                  <Badge className="userBadge">Name</Badge>{" "}
                   {props.user.username}
                 </Col>
                 <Col xs={12} style={{ marginBottom: 3 }}>
@@ -33,7 +33,7 @@ const Settings = props => {
                 </Col>
                 {props.user.subscribed ? (
                   <Col xs={12} style={{ marginBottom: 3 }}>
-                    <Badge className="expireBadge">Expiration</Badge>
+                    <Badge className="expireBadge">Ends</Badge>
                     {" " + dateFormat(props.user.subscriptionEnd)}
                   </Col>
                 ) : null}

--- a/client/src/components/Settings/index.js
+++ b/client/src/components/Settings/index.js
@@ -29,7 +29,7 @@ const Settings = props => {
                 </Col>
                 <Col xs={12} style={{ marginBottom: 3 }}>
                   <Badge className="tierBadge">Tier</Badge>{" "}
-                  {props.user.subscribed ? "Paid" : "Free"}
+                  {props.user.subscribed ? "Premium" : "Free"}
                 </Col>
                 {props.user.subscribed ? (
                   <Col xs={12} style={{ marginBottom: 3 }}>

--- a/client/src/components/Settings/settings.css
+++ b/client/src/components/Settings/settings.css
@@ -1,7 +1,8 @@
 .userBadge,
 .tierBadge,
-.expireBadge {
+.expireBadge,
+.emailBadge {
   width: 25%;
-  margin-right: 2%;
+  margin-right: 3%;
   text-align: center;
 }

--- a/client/src/components/Settings/settings.css
+++ b/client/src/components/Settings/settings.css
@@ -1,8 +1,7 @@
 .userBadge,
 .tierBadge,
-.expireBadge,
-.emailBadge {
-  width: 25%;
+.expireBadge {
+  width: 17%;
   margin-right: 3%;
   text-align: center;
 }


### PR DESCRIPTION
# Description

Made the current set of badges more responsive across firefox, safari and chrome browsers added className='text-truncate' to documentlist cards for title and addressee in order for cards to stay a uniform height.  Changed occurences of the word paid to premium.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts

# Reviewers:
  @ceejaay
  @jcuffe
  @Ta1grr
  @fron12
  @rverdi642
  @wtkwon
